### PR TITLE
Update clickable link to link to Gitlab

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ by James Bearden and is not endorsed by or affiliated with Discord.
 
 ## Development
 
-Build and run using [clickable](https://github.com/bhdouglass/clickable).
+Build and run using [clickable](https://gitlab.com/clickable/clickable).
 
 ## License
 


### PR DESCRIPTION
Clickable has moved to Gitlab (as per their About section on GitHub), let's link there directly.